### PR TITLE
iata_bcbp 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 readme = "README.md"
 documentation = "https://martinmroz.github.io/iata_bcbp/master/iata_bcbp/"
 description = "IATA BCBP Parser in Rust Based on Resolution 792"
+edition = "2018"
 
 [dependencies]
 arrayvec = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iata_bcbp"
-version = "0.1.1"
+version = "1.0.0"
 authors = ["Martin Mroz <martinmroz@gmail.com>"]
 repository = "https://github.com/martinmroz/iata_bcbp.git"
 homepage = "https://github.com/martinmroz/iata_bcbp.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ documentation = "https://martinmroz.github.io/iata_bcbp/master/iata_bcbp/"
 description = "IATA BCBP Parser in Rust Based on Resolution 792"
 
 [dependencies]
-log = "0.4"
+arrayvec = "0.4"
 
-[dev-dependencies]
-env_logger = "0.5"
+[dependencies.nom]
+version = "^5"
+features = []

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-iata_bcbp = "0.1"
+iata_bcbp = "1.0"
 ```
 
 In addition, and this to your crate root:

--- a/src/bcbp/mod.rs
+++ b/src/bcbp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.
@@ -58,7 +58,9 @@ impl Leg {
     /// Spaces indicate the field is not set.
     /// Any other values are invalid.
     pub fn marketing_carrier_designator(&self) -> Option<&str> {
-        self.marketing_carrier_designator.as_ref().map(|x| &**x)
+        self.marketing_carrier_designator
+            .as_ref()
+            .map(|x| x.as_str())
     }
 
     /// Airline code associated with the frequent flyer number.
@@ -69,7 +71,7 @@ impl Leg {
     pub fn frequent_flyer_airline_designator(&self) -> Option<&str> {
         self.frequent_flyer_airline_designator
             .as_ref()
-            .map(|x| &**x)
+            .map(|x| x.as_str())
     }
 
     /// 2 character or 3 letter airline designator followed by up to 13 numerics or
@@ -77,7 +79,9 @@ impl Leg {
     /// Spaces indicate the field is not set.
     /// Any other values are invalid.
     pub fn frequent_flyer_number(&self) -> Option<&str> {
-        self.frequent_flyer_number.as_ref().map(|x| &**x)
+        self.frequent_flyer_number
+            .as_ref()
+            .map(|x| x.as_str())
     }
 
     /// Values are defined in Resolution 792.
@@ -144,14 +148,18 @@ impl Leg {
     /// This is also the first three digits of the eTicket number.
     /// Spaces indicate the field is not set.
     pub fn airline_numeric_code(&self) -> Option<&str> {
-        self.airline_numeric_code.as_ref().map(|x| &**x)
+        self.airline_numeric_code
+            .as_ref()
+            .map(|x| x.as_str())
     }
 
     /// The ten-digit DSN.
     /// This is also the last ten digits of the eTicket number.
     /// Spaces indicate the field is not set.
     pub fn document_form_serial_number(&self) -> Option<&str> {
-        self.document_form_serial_number.as_ref().map(|x| &**x)
+        self.document_form_serial_number
+            .as_ref()
+            .map(|x| x.as_str())
     }
 
     /// This field is used by certain agencies to demarcate individuals requiring extra screening.
@@ -180,13 +188,17 @@ impl Leg {
     /// indicating how much baggage passengers are able to take with them free of charge.
     /// Spaces indicate the field is not set.
     pub fn free_baggage_allowance(&self) -> Option<&str> {
-        self.free_baggage_allowance.as_ref().map(|x| &**x)
+        self.free_baggage_allowance
+            .as_ref()
+            .map(|x| x.as_str())
     }
 
     /// Optional unstructured data for airline individual use.
     /// Content frequently includes frequent flyer tier, passenger preferences, etc.
     pub fn airline_individual_use(&self) -> Option<&str> {
-        self.airline_individual_use.as_ref().map(|x| &**x)
+        self.airline_individual_use
+            .as_ref()
+            .map(|x| x.as_str())
     }
 }
 
@@ -204,23 +216,31 @@ impl SecurityData {
 
     /// Security data used to verify the boarding pass was not tampered with.
     pub fn security_data(&self) -> Option<&str> {
-        self.security_data.as_ref().map(|x| &**x)
+        self.security_data
+            .as_ref()
+            .map(|x| x.as_str())
     }
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
+pub(crate) struct ConditionalMetadata {
+    pub(crate) version_number: Option<char>,
+    pub(crate) passenger_description: Option<char>,
+    pub(crate) source_of_check_in: Option<char>,
+    pub(crate) source_of_boarding_pass_issuance: Option<char>,
+    pub(crate) date_of_issue_of_boarding_pass: Option<ArrayString<[u8; 4]>>,
+    pub(crate) document_type: Option<char>,
+    pub(crate) airline_designator_of_boarding_pass_issuer: Option<ArrayString<[u8; 3]>>,
+    pub(crate) baggage_tag_license_plate_numbers: Option<ArrayString<[u8; 13]>>,
+    pub(crate) first_non_consecutive_baggage_tag_license_plate_numbers: Option<ArrayString<[u8; 13]>>,
+    pub(crate) second_non_consecutive_baggage_tag_license_plate_numbers: Option<ArrayString<[u8; 13]>>,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Bcbp {
     pub(crate) passenger_name: ArrayString<[u8; 20]>,
     pub(crate) electronic_ticket_indicator: char,
-    pub(crate) passenger_description: Option<char>,
-    pub(crate) source_of_check_in: Option<char>,
-    pub(crate) source_of_boarding_pass_issuance: Option<char>,
-    pub(crate) date_of_issue_of_boarding_pass: Option<String>,
-    pub(crate) document_type: Option<char>,
-    pub(crate) airline_designator_of_boarding_pass_issuer: Option<String>,
-    pub(crate) baggage_tag_license_plate_numbers: Option<String>,
-    pub(crate) first_non_consecutive_baggage_tag_license_plate_numbers: Option<String>,
-    pub(crate) second_non_consecutive_baggage_tag_license_plate_numbers: Option<String>,
+    pub(crate) metadata: ConditionalMetadata,
     pub(crate) legs: Vec<Leg>,
     pub(crate) security_data: SecurityData,
 }
@@ -244,11 +264,19 @@ impl Bcbp {
         self.electronic_ticket_indicator
     }
 
+    /// Indicates the version number of the BCBP object.
+    /// Values are defined in Resolution 792.
+    /// None indicates the value was not specified in the object.
+    /// Some space literal indicates the field existed in the object but was not set.
+    pub fn version_number(&self) -> Option<char> {
+        self.metadata.version_number
+    }
+
     /// This describes the passenger.
     /// Values are defined in Resolution 792.
     /// Spaces indicate the field is not set.
     pub fn passenger_description(&self) -> Option<char> {
-        self.passenger_description
+        self.metadata.passenger_description
     }
 
     /// The name of the passenger. Up to 20 characters, left-aligned, space padded.
@@ -265,14 +293,14 @@ impl Bcbp {
     /// Values are defined in Resolution 792 Attachment C.
     /// Spaces indicate the field is not set.
     pub fn source_of_check_in(&self) -> Option<char> {
-        self.source_of_check_in
+        self.metadata.source_of_check_in
     }
 
     /// This field reflects channel which issued the boarding pass.
     /// Values are defined in Resolution 792.
     /// Spaces indicate the field is not set.
     pub fn source_of_boarding_pass_issuance(&self) -> Option<char> {
-        self.source_of_boarding_pass_issuance
+        self.metadata.source_of_boarding_pass_issuance
     }
 
     /// Optionally the 4-digit Julian date representing when the boarding pass
@@ -283,13 +311,16 @@ impl Bcbp {
     ///   "6366" represents December 31, 2016 (a leap year).
     /// Spaces indicate the field is not set.
     pub fn date_of_issue_of_boarding_pass(&self) -> Option<&str> {
-        self.date_of_issue_of_boarding_pass.as_ref().map(|x| &**x)
+        self.metadata
+            .date_of_issue_of_boarding_pass
+            .as_ref()
+            .map(|x| x.as_str())
     }
 
     /// The type of the document, 'B' indicating a boarding pass.
     /// Spaces indicate the field is not set.
     pub fn document_type(&self) -> Option<char> {
-        self.document_type
+        self.metadata.document_type
     }
 
     /// Airline code of the boarding pass issuer.
@@ -297,9 +328,10 @@ impl Bcbp {
     /// are permitted and the string is left-justified and space padded.
     /// Spaces indicate the field is not set.
     pub fn airline_designator_of_boarding_pass_issuer(&self) -> Option<&str> {
-        self.airline_designator_of_boarding_pass_issuer
+        self.metadata
+            .airline_designator_of_boarding_pass_issuer
             .as_ref()
-            .map(|x| &**x)
+            .map(|x| x.as_str())
     }
 
     /// This field allows carriers to populate baggage tag numbers and the number
@@ -310,26 +342,29 @@ impl Bcbp {
     ///   11...13: number of consecutive bags (up to 999).
     /// Spaces indicate the field is not set.
     pub fn baggage_tag_license_plate_numbers(&self) -> Option<&str> {
-        self.baggage_tag_license_plate_numbers
+        self.metadata
+            .baggage_tag_license_plate_numbers
             .as_ref()
-            .map(|x| &**x)
+            .map(|x| x.as_str())
     }
 
     /// This field allows carriers who handle non-sequential bags to include a second set of them
     /// in the boarding pass data in in the same format as `baggage_tag_license_plate_numbers`.
     /// Spaces indicate the field is not set.
     pub fn first_non_consecutive_baggage_tag_license_plate_numbers(&self) -> Option<&str> {
-        self.first_non_consecutive_baggage_tag_license_plate_numbers
+        self.metadata
+            .first_non_consecutive_baggage_tag_license_plate_numbers
             .as_ref()
-            .map(|x| &**x)
+            .map(|x| x.as_str())
     }
 
     /// This field allows carriers who handle non-sequential bags to include a third set of them
     /// in the boarding pass data in in the same format as `baggage_tag_license_plate_numbers`.
     /// Spaces indicate the field is not set.
     pub fn second_non_consecutive_baggage_tag_license_plate_numbers(&self) -> Option<&str> {
-        self.second_non_consecutive_baggage_tag_license_plate_numbers
+        self.metadata
+            .second_non_consecutive_baggage_tag_license_plate_numbers
             .as_ref()
-            .map(|x| &**x)
+            .map(|x| x.as_str())
     }
 }

--- a/src/bcbp/mod.rs
+++ b/src/bcbp/mod.rs
@@ -3,33 +3,34 @@
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.
 
-#[derive(Clone,Eq,PartialEq,Hash,Debug,Default)]
+use arrayvec::ArrayString;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Leg {
-    pub(crate) operating_carrier_pnr_code: String,
-    pub(crate) from_city_airport_code: String,
-    pub(crate) to_city_airport_code: String,
-    pub(crate) operating_carrier_designator: String,
-    pub(crate) flight_number: String,
-    pub(crate) date_of_flight: String,
+    pub(crate) operating_carrier_pnr_code: ArrayString<[u8; 7]>,
+    pub(crate) from_city_airport_code: ArrayString<[u8; 3]>,
+    pub(crate) to_city_airport_code: ArrayString<[u8; 3]>,
+    pub(crate) operating_carrier_designator: ArrayString<[u8; 3]>,
+    pub(crate) flight_number: ArrayString<[u8; 5]>,
+    pub(crate) date_of_flight: ArrayString<[u8; 3]>,
     pub(crate) compartment_code: char,
-    pub(crate) seat_number: String,
-    pub(crate) check_in_sequence_number: String,
+    pub(crate) seat_number: ArrayString<[u8; 4]>,
+    pub(crate) check_in_sequence_number: ArrayString<[u8; 5]>,
     pub(crate) passenger_status: char,
-    pub(crate) airline_numeric_code: Option<String>,
-    pub(crate) document_form_serial_number: Option<String>,
+    pub(crate) airline_numeric_code: Option<ArrayString<[u8; 3]>>,
+    pub(crate) document_form_serial_number: Option<ArrayString<[u8; 10]>>,
     pub(crate) selectee_indicator: Option<char>,
     pub(crate) international_document_verification: Option<char>,
-    pub(crate) marketing_carrier_designator: Option<String>,
-    pub(crate) frequent_flyer_airline_designator: Option<String>,
-    pub(crate) frequent_flyer_number: Option<String>,
+    pub(crate) marketing_carrier_designator: Option<ArrayString<[u8; 3]>>,
+    pub(crate) frequent_flyer_airline_designator: Option<ArrayString<[u8; 3]>>,
+    pub(crate) frequent_flyer_number: Option<ArrayString<[u8; 16]>>,
     pub(crate) id_ad_indicator: Option<char>,
-    pub(crate) free_baggage_allowance: Option<String>,
+    pub(crate) free_baggage_allowance: Option<ArrayString<[u8; 3]>>,
     pub(crate) fast_track: Option<char>,
     pub(crate) airline_individual_use: Option<String>,
 }
 
 impl Leg {
-
     /// An alphanumeric string of up to 6 characters, left-aligned, space-padded.
     /// This is the Passenger Name Record used to identify the booking
     /// in the reservation system of the operating carrier.
@@ -50,7 +51,7 @@ impl Leg {
     pub fn to_city_airport_code(&self) -> &str {
         &self.to_city_airport_code
     }
-    
+
     /// Airline code of the marketing carrier, which can be the same as the operating carrier.
     /// Two-character and three-letter IATA carrier designators
     /// are permitted and the string is left-justified and space padded.
@@ -66,7 +67,9 @@ impl Leg {
     /// Spaces indicate the field is not set.
     /// Any other values are invalid.
     pub fn frequent_flyer_airline_designator(&self) -> Option<&str> {
-        self.frequent_flyer_airline_designator.as_ref().map(|x| &**x)
+        self.frequent_flyer_airline_designator
+            .as_ref()
+            .map(|x| &**x)
     }
 
     /// 2 character or 3 letter airline designator followed by up to 13 numerics or
@@ -185,17 +188,15 @@ impl Leg {
     pub fn airline_individual_use(&self) -> Option<&str> {
         self.airline_individual_use.as_ref().map(|x| &**x)
     }
-
 }
 
-#[derive(Clone,Eq,PartialEq,Hash,Debug,Default)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct SecurityData {
     pub(crate) type_of_security_data: Option<char>,
     pub(crate) security_data: Option<String>,
 }
 
 impl SecurityData {
-
     /// Vendor specific flag indicating the type of the security data which follows.
     pub fn type_of_security_data(&self) -> Option<char> {
         self.type_of_security_data
@@ -205,12 +206,11 @@ impl SecurityData {
     pub fn security_data(&self) -> Option<&str> {
         self.security_data.as_ref().map(|x| &**x)
     }
-
 }
 
-#[derive(Clone,Eq,PartialEq,Hash,Debug,Default)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Bcbp {
-    pub(crate) passenger_name: String,
+    pub(crate) passenger_name: ArrayString<[u8; 20]>,
     pub(crate) electronic_ticket_indicator: char,
     pub(crate) passenger_description: Option<char>,
     pub(crate) source_of_check_in: Option<char>,
@@ -226,7 +226,6 @@ pub struct Bcbp {
 }
 
 impl Bcbp {
-
     /// All legs encoded into the boarding pass.
     /// At least one needs to be present to form a valid boarding pass.
     pub fn legs(&self) -> &[Leg] {
@@ -244,14 +243,14 @@ impl Bcbp {
     pub fn electronic_ticket_indicator(&self) -> char {
         self.electronic_ticket_indicator
     }
-    
+
     /// This describes the passenger.
     /// Values are defined in Resolution 792.
     /// Spaces indicate the field is not set.
     pub fn passenger_description(&self) -> Option<char> {
         self.passenger_description
     }
-    
+
     /// The name of the passenger. Up to 20 characters, left-aligned, space padded.
     /// The format is `LAST_NAME/FIRST_NAME[TITLE]`. There is no separator between
     /// the first name and the title, and no indication a title is present.
@@ -280,8 +279,8 @@ impl Bcbp {
     /// was issued. The first digit is the last digit of the year and the next three
     /// represent the number of days elapsed.
     /// For example:
-    ///   "6001" represnts January 1, 2016.
-    ///   "6366" represaents December 31, 2016 (a leap year).
+    ///   "6001" represents January 1, 2016.
+    ///   "6366" represents December 31, 2016 (a leap year).
     /// Spaces indicate the field is not set.
     pub fn date_of_issue_of_boarding_pass(&self) -> Option<&str> {
         self.date_of_issue_of_boarding_pass.as_ref().map(|x| &**x)
@@ -298,7 +297,9 @@ impl Bcbp {
     /// are permitted and the string is left-justified and space padded.
     /// Spaces indicate the field is not set.
     pub fn airline_designator_of_boarding_pass_issuer(&self) -> Option<&str> {
-        self.airline_designator_of_boarding_pass_issuer.as_ref().map(|x| &**x)
+        self.airline_designator_of_boarding_pass_issuer
+            .as_ref()
+            .map(|x| &**x)
     }
 
     /// This field allows carriers to populate baggage tag numbers and the number
@@ -309,21 +310,26 @@ impl Bcbp {
     ///   11...13: number of consecutive bags (up to 999).
     /// Spaces indicate the field is not set.
     pub fn baggage_tag_license_plate_numbers(&self) -> Option<&str> {
-        self.baggage_tag_license_plate_numbers.as_ref().map(|x| &**x)
+        self.baggage_tag_license_plate_numbers
+            .as_ref()
+            .map(|x| &**x)
     }
 
     /// This field allows carriers who handle non-sequential bags to include a second set of them
     /// in the boarding pass data in in the same format as `baggage_tag_license_plate_numbers`.
     /// Spaces indicate the field is not set.
     pub fn first_non_consecutive_baggage_tag_license_plate_numbers(&self) -> Option<&str> {
-        self.first_non_consecutive_baggage_tag_license_plate_numbers.as_ref().map(|x| &**x)
+        self.first_non_consecutive_baggage_tag_license_plate_numbers
+            .as_ref()
+            .map(|x| &**x)
     }
 
     /// This field allows carriers who handle non-sequential bags to include a third set of them
     /// in the boarding pass data in in the same format as `baggage_tag_license_plate_numbers`.
     /// Spaces indicate the field is not set.
     pub fn second_non_consecutive_baggage_tag_license_plate_numbers(&self) -> Option<&str> {
-        self.second_non_consecutive_baggage_tag_license_plate_numbers.as_ref().map(|x| &**x)
+        self.second_non_consecutive_baggage_tag_license_plate_numbers
+            .as_ref()
+            .map(|x| &**x)
     }
-
 }

--- a/src/de/field.rs
+++ b/src/de/field.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.

--- a/src/de/field.rs
+++ b/src/de/field.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-#[derive(Copy,Clone,Eq,PartialEq,Ord,PartialOrd,Debug,Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub enum Field {
     /// Item 1: Format Code. 1 byte. Data Type 'f'.
     FormatCode,
@@ -96,7 +96,6 @@ pub enum Field {
 }
 
 impl Field {
-
     /// The required length of the field. If zero, the field may be arbitrarily long.
     pub fn len(self) -> usize {
         match self {
@@ -149,95 +148,94 @@ impl Field {
     /// Name of the field as defined in the Implementation Guide.
     pub fn name(self) -> &'static str {
         match self {
-            Field::FormatCode => 
+            Field::FormatCode =>
                 "Format Code",
-            Field::AirlineIndividualUse => 
+            Field::AirlineIndividualUse =>
                 "Airline Individual Use",
-            Field::NumberOfLegsEncoded => 
+            Field::NumberOfLegsEncoded =>
                 "Number of Legs Encoded",
-            Field::FieldSizeOfVariableSizeField => 
+            Field::FieldSizeOfVariableSizeField =>
                 "Field Size of Variable Size Field",
-            Field::OperatingCarrierPnrCode => 
+            Field::OperatingCarrierPnrCode =>
                 "Operating Carrier PNR Code",
-            Field::BeginningOfVersionNumber => 
+            Field::BeginningOfVersionNumber =>
                 "Beginning of Version Number",
-            Field::VersionNumber => 
+            Field::VersionNumber =>
                 "Version Number",
-            Field::FieldSizeOfStructuredMessageUnique => 
+            Field::FieldSizeOfStructuredMessageUnique =>
                 "Field Size of Strutured Message (Unique)",
-            Field::PassengerName => 
+            Field::PassengerName =>
                 "Passenger Name",
-            Field::SourceOfCheckIn => 
+            Field::SourceOfCheckIn =>
                 "Source of Check-In",
-            Field::SourceOfBoardingPassIssuance => 
+            Field::SourceOfBoardingPassIssuance =>
                 "Source of Boarding Pass Issuance",
-            Field::PassengerDescription => 
+            Field::PassengerDescription =>
                 "Passenger Description",
-            Field::DocumentType => 
+            Field::DocumentType =>
                 "Document Type",
-            Field::FieldSizeOfStructuredMessageRepeated => 
+            Field::FieldSizeOfStructuredMessageRepeated =>
                 "Field Size of Strutured Message (Repeated)",
-            Field::SelecteeIndicator => 
+            Field::SelecteeIndicator =>
                 "Selectee Indicator",
-            Field::MarketingCarrierDesignator => 
+            Field::MarketingCarrierDesignator =>
                 "Marketing Carrier Designator",
-            Field::FrequentFlyerAirlineDesignator => 
+            Field::FrequentFlyerAirlineDesignator =>
                 "Frequent Flyer Airline Designator",
-            Field::AirlineDesignatorOfBoardingPassIssuer => 
+            Field::AirlineDesignatorOfBoardingPassIssuer =>
                 "Airline Designator of Boarding Pass Issuer",
-            Field::DateOfIssueOfBoardingPass => 
+            Field::DateOfIssueOfBoardingPass =>
                 "Date of Issue of Boarding Pass",
-            Field::BaggageTagLicensePlateNumbers => 
+            Field::BaggageTagLicensePlateNumbers =>
                 "Baggage Tag License Plate Number(s)",
-            Field::BeginningOfSecurityData => 
+            Field::BeginningOfSecurityData =>
                 "Beginning of Security Data",
-            Field::FromCityAirportCode => 
+            Field::FromCityAirportCode =>
                 "From City Airport Code",
-            Field::TypeOfSecurityData => 
+            Field::TypeOfSecurityData =>
                 "Type of Security Data",
-            Field::LengthOfSecurityData => 
+            Field::LengthOfSecurityData =>
                 "Length of Security Data",
-            Field::SecurityData => 
+            Field::SecurityData =>
                 "Security Data",
             Field::FirstNonConsecutiveBaggageTagLicensePlateNumbers =>
                 "First Non-Consecutive Baggage Tag License Plate Number",
             Field::SecondNonConsecutiveBaggageTagLicensePlateNumbers =>
                 "Second Non-Consecutive Baggage Tag License Plate Number",
-            Field::ToCityAirportCode => 
+            Field::ToCityAirportCode =>
                 "To City Airport Code",
-            Field::OperatingCarrierDesignator => 
+            Field::OperatingCarrierDesignator =>
                 "Operating Carrier Designator",
-            Field::FlightNumber => 
+            Field::FlightNumber =>
                 "Flight Number",
-            Field::DateOfFlight => 
+            Field::DateOfFlight =>
                 "Date of Flight",
-            Field::CompartmentCode => 
+            Field::CompartmentCode =>
                 "Compartment Code",
-            Field::IdAdIndicator => 
+            Field::IdAdIndicator =>
                 "ID/AD Indicator",
-            Field::SeatNumber => 
+            Field::SeatNumber =>
                 "Seat Number",
-            Field::CheckInSequenceNumber => 
+            Field::CheckInSequenceNumber =>
                 "Check-In Sequence Number",
-            Field::InternationalDocumentVerification => 
+            Field::InternationalDocumentVerification =>
                 "International Document Verification",
-            Field::PassengerStatus => 
+            Field::PassengerStatus =>
                 "Passenger Status",
-            Field::FreeBaggageAllowance => 
+            Field::FreeBaggageAllowance =>
                 "Free Baggage Allowance",
-            Field::AirlineNumericCode => 
+            Field::AirlineNumericCode =>
                 "Airline Numeric Code",
-            Field::DocumentFormSerialNumber => 
+            Field::DocumentFormSerialNumber =>
                 "Document Form / Serial Number",
-            Field::FrequentFlyerNumber => 
+            Field::FrequentFlyerNumber =>
                 "Frequent Flyer Number",
-            Field::ElectronicTicketIndicator => 
+            Field::ElectronicTicketIndicator =>
                 "Electronic Ticket Indicator",
-            Field::FastTrack => 
+            Field::FastTrack =>
                 "Fast Track",
         }
     }
-
 }
 
 impl fmt::Display for Field {

--- a/src/de/field.rs
+++ b/src/de/field.rs
@@ -5,8 +5,9 @@
 
 use std::fmt;
 
+#[allow(dead_code)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
-pub enum Field {
+pub(crate) enum Field {
     /// Item 1: Format Code. 1 byte. Data Type 'f'.
     FormatCode,
     /// Item 4: Airline Individual Use. n bytes. Data Type unspecified.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -5,11 +5,11 @@
 
 use std::str::FromStr;
 
-pub mod field;
+mod field;
 mod parser;
 
-use bcbp;
-use error::{Error, Result};
+use crate::bcbp;
+use crate::error::{Error, Result};
 
 pub use self::parser::from_str;
 

--- a/src/de/parser.rs
+++ b/src/de/parser.rs
@@ -4,303 +4,234 @@
 // of the MIT license.  See the LICENSE file for details.
 
 use bcbp;
-use error::{Error, Result};
 use de::field;
+use error::{Error, Result};
 
-#[derive(Clone,Eq,PartialEq,Hash,Debug)]
-struct Scanner<'a> {
-    input: &'a str,
+use arrayvec::{Array, ArrayString};
+use nom::{
+    bytes::complete::{take, take_while_m_n},
+    character::complete::{anychar, char},
+    combinator::map_res,
+    error::{context, convert_error, VerboseError},
+    IResult,
+};
+
+/// Tests if char c is ASCII uppercase alphabetic (A-F) or numeric (0-9).
+fn is_ascii_uppercase_hexdigit(c: char) -> bool {
+    c.is_ascii_hexdigit() && !c.is_ascii_lowercase()
 }
 
-impl<'a> Scanner<'a> {
+/// Parses a one- or two-digit ASCII uppercase hexadecimal string literal value.
+///
+/// # Notes
+/// - Does not provide additional context.
+fn hex_byte_literal<'a>(
+    input: &'a str,
+    length: usize,
+) -> IResult<&'a str, u8, VerboseError<&'a str>> {
+    assert!(length == 1 || length == 2);
+    map_res(
+        take_while_m_n(length, length, is_ascii_uppercase_hexdigit),
+        |s: &str| u8::from_str_radix(s, 16),
+    )(input)
+}
 
-    /// Return a new intance of the receiver over the `input`.
-    pub fn new(input: &'a str) -> Self {
-        Scanner { input }
+/// Parses the field encoding the number of legs embedded in the BCBP data.
+fn number_of_legs<'a>(input: &'a str) -> IResult<&'a str, u8, VerboseError<&'a str>> {
+    context(field::Field::NumberOfLegsEncoded.name(), |input| {
+        hex_byte_literal(input, 1)
+    })(input)
+}
+
+/// Parses and yields the variable-size conditional items field for a flight leg.
+fn leg_conditional_items<'a>(input: &'a str) -> IResult<&'a str, &'a str, VerboseError<&'a str>> {
+    let (input, length) = context(field::Field::FieldSizeOfVariableSizeField.name(), |input| {
+        hex_byte_literal(input, 2)
+    })(input)?;
+
+    match length {
+        0 => Ok((input, "")),
+        _ => take(length as usize)(input),
+    }
+}
+
+/// Parses the format code specifier tag for an M-type IATA BCBP pass.
+fn format_code_m<'a>(input: &'a str) -> IResult<&'a str, char, VerboseError<&'a str>> {
+    context(field::Field::FormatCode.name(), 
+        char('M')
+    )(input)
+}
+
+/// Parses a fixed-length String-type field.
+fn string_field<'a, T>(
+    input: &'a str,
+    field_id: field::Field,
+) -> IResult<&'a str, ArrayString<T>, VerboseError<&'a str>>
+where
+    T: Array<Item = u8> + Copy,
+{
+    // Verify that the size of the storage array matches the field exactly.
+    assert_eq!(std::mem::size_of::<T>(), field_id.len());
+
+    // Copies bytes equal to the length of the specified field into an ArrayString.
+    let parse_field = map_res(
+        take(field_id.len()), 
+        |s: &str| ArrayString::from(s)
+    );
+
+    // Ascribe the name of the field as context for the operation.
+    context(field_id.name(), parse_field)(input)
+}
+
+/// Parses an optional fixed-length String-type field within a variable-length section.
+///
+/// # Notes
+/// - This function will succeed and return None if the remaining length of the string is zero.
+/// - This function will fail if the remaining length of the string is less than that of the requested field.
+fn optional_string_field<'a, T>(
+    input: &'a str,
+    field_id: field::Field,
+) -> IResult<&'a str, Option<ArrayString<T>>, VerboseError<&'a str>>
+where
+    T: Array<Item = u8> + Copy,
+{
+    if input.len() == 0 {
+        Ok((input, None))
+    } else {
+        string_field(input, field_id).map(|(input, field)| (input, Some(field)))
+    }
+}
+
+/// Parses a single-character field.
+fn character_field<'a>(
+    input: &'a str,
+    field_id: field::Field,
+) -> IResult<&'a str, char, VerboseError<&'a str>> {
+    assert_eq!(field_id.len(), 1);
+    context(field_id.name(), anychar)(input)
+}
+
+/// Parses an optional single-character field within a variable-length section.
+///
+/// # Notes
+/// - This function will succeed and return None if the remaining length of the string is zero.
+fn optional_character_field<'a>(
+    input: &'a str,
+    field_id: field::Field,
+) -> IResult<&'a str, Option<char>, VerboseError<&'a str>> {
+    if (input.len() == 0) {
+        Ok((input, None))
+    } else {
+        character_field(input, field_id).map(|(input, field)| (input, Some(field)))
+    }
+}
+
+/// Parses a boarding pass from `input`.
+///
+/// The input must contain only valid ASCII characters.
+fn bcbp<'a>(input: &'a str) -> IResult<&'a str, bcbp::Bcbp, VerboseError<&'a str>> {
+    // Check that the input string is likely an M-type BCBP string.
+    let (input, _) = format_code_m(input)?;
+
+    // The number of legs informs the breakdown of the various field iterators.
+    let (input, number_of_legs_encoded) = number_of_legs(input)?;
+
+    // Scan mandatory unique fields.
+    let (input, passenger_name) = 
+        string_field(input, field::Field::PassengerName)?;
+    let (input, electronic_ticket_indicator) =
+        character_field(input, field::Field::ElectronicTicketIndicator)?;
+
+    let mut legs = Vec::new();
+
+    for leg_index in 0 .. number_of_legs_encoded {
+        // Mandatory fields common to all legs.
+        let (input, operating_carrier_pnr_code) =
+            string_field(input, field::Field::OperatingCarrierPnrCode)?;
+        let (input, from_city_airport_code) =
+            string_field(input, field::Field::FromCityAirportCode)?;
+        let (input, to_city_airport_code) = 
+            string_field(input, field::Field::ToCityAirportCode)?;
+        let (input, operating_carrier_designator) =
+            string_field(input, field::Field::OperatingCarrierDesignator)?;
+        let (input, flight_number) = 
+            string_field(input, field::Field::FlightNumber)?;
+        let (input, date_of_flight) = 
+            string_field(input, field::Field::DateOfFlight)?;
+        let (input, compartment_code) = 
+            character_field(input, field::Field::CompartmentCode)?;
+        let (input, seat_number) = 
+            string_field(input, field::Field::SeatNumber)?;
+        let (input, check_in_sequence_number) =
+            string_field(input, field::Field::CheckInSequenceNumber)?;
+        let (input, passenger_status) = 
+            character_field(input, field::Field::PassengerStatus)?;
+
+        // A set of conditional items may follow the required items for each leg.
+        let (input, conditional_items_input) = leg_conditional_items(input)?;
+
+        legs.push(bcbp::Leg {
+            operating_carrier_pnr_code,
+            from_city_airport_code,
+            to_city_airport_code,
+            operating_carrier_designator,
+            flight_number,
+            date_of_flight,
+            compartment_code,
+            seat_number,
+            check_in_sequence_number,
+            passenger_status,
+            ..Default::default()
+        });
     }
 
-    /// Returns `true` if no more input is available.
-    #[inline]
-    pub fn is_at_end(&self) -> bool {
-        self.remaining_len() == 0
-    }
-
-    /// Returns the number of bytes of input remaining to process.
-    #[inline]
-    pub fn remaining_len(&self) -> usize {
-        self.input.len()
-    }
-
-    /// Returns a scanner over a fixed-length sub-section of the input.
-    /// The entire amount is consumed immediately if space is available whether or not
-    /// any fields within the sub-section are invalid.
-    /// 
-    /// # Panics
-    /// Will panic if `len` is `0`.
-    pub fn scan_subsection(&mut self, len: usize) -> Result<Scanner<'a>> {
-        assert!(len > 0, "Attempting to scan a zero-length sub-field list is not valid.");
-        trace!("Scanning Subsection (Length {})", len);
-        if self.remaining_len() < len {
-            Err(Error::SubsectionTooLong)
-        } else {
-            let sub_fields = &self.input[ .. len ];
-            self.input = &self.input[ len .. ];
-            Ok(Scanner::new(sub_fields))
-        }
-    }
-
-    /// Scans and returns the string underlying a field (variable or fixed-length)
-    /// with a specified length value.
-    /// 
-    /// # Panics
-    /// Will panic if `len` is `0`.
-    /// Will panic if the fixed-length field intrinsic length is not equal to `len`.
-    pub fn scan_str_field_len(&mut self, field: field::Field, len: usize) -> Result<&'a str> {
-        assert!(len > 0, "Attempting to scan zero bytes of data.");
-        assert!(field.len() == 0 || field.len() == len, "Length is not compatible the intrinsic length of the field.");
-        if self.remaining_len() < len {
-            trace!("Unexpected End of Input Scanning {} (Length {})", field, len);
-            Err(Error::UnexpectedEndOfInput(field))
-        } else {
-            let substring = &self.input[ .. len ];
-            self.input = &self.input[ len .. ];
-            trace!("Scanning {} (Length {}) - '{}'", field, len, substring);
-            Ok(substring)
-        }
-    }
-
-    /// Scans and returns the string underlying a fixed-length field.
-    /// Uses the intrinsic length.
-    /// 
-    /// # Panics
-    /// Will panic if `field` is variable-length.
-    pub fn scan_str_field(&mut self, field: field::Field) -> Result<&'a str> {
-        assert!(field.len() != 0, "Attempting to scan a variable-length field as fixed-length.");
-        self.scan_str_field_len(field, field.len())
-    }
-
-    /// Scans and returns an optional string underlying a fixed-length field.
-    /// If there is no more input to process, returns `Ok(None)`.
-    /// Uses the intrinsic length.
-    /// 
-    /// # Panics
-    /// Will panic if `field` is variable-length.
-    pub fn scan_optional_str_field(&mut self, field: field::Field) -> Result<Option<&'a str>> {
-        assert!(field.len() != 0, "Attempting to scan a variable-length field as fixed-length.");
-        if self.is_at_end() {
-            Ok(None)
-        } else {
-            self.scan_str_field(field).map(|result| Some(result))
-        }
-    }
-
-    /// Scans a fixed-length numeric field yielding the numeric value interpreted
-    /// with the given `radix`.
-    /// 
-    /// # Panics
-    /// Will panic if `field` is variable-length.
-    /// 
-    /// # Issues
-    /// Should not advance the input until the numeric value is sucessfully scanned.
-    pub fn scan_unsigned_field(&mut self, field: field::Field, radix: u32) -> Result<u64> {
-        self.scan_str_field(field)
-            .and_then(|str_value| {
-                u64::from_str_radix(str_value, radix).map_err(|_| Error::ExpectedInteger(field))
-            })
-    }
-
-    /// Scans and returns the character value underlying a fixed-length field.
-    /// 
-    /// # Panics
-    /// Will panic if `field` is a length other than 1.
-    pub fn scan_char_field(&mut self, field: field::Field) -> Result<char> {
-        assert!(field.len() == 1, "Attempting to scan a single character out of a longer field.");
-        self.scan_str_field(field)
-            .map(|value| value.chars().next().unwrap())
-    }
-
-    /// Scans and returns an optional character value underlying a fixed-length field.
-    /// If there is no more input to process, returns `Ok(None)`.
-    /// 
-    /// # Panics
-    /// Will panic if `field` is a length other than 1.
-    pub fn scan_optional_char_field(&mut self, field: field::Field) -> Result<Option<char>> {
-        assert!(field.len() == 1, "Attempting to scan a single character out of a longer field.");
-        if self.is_at_end() {
-            Ok(None)
-        } else {
-            self.scan_char_field(field).map(|c| Some(c))
-        }
-    }
-
+    Ok((
+        input,
+        bcbp::Bcbp {
+            passenger_name,
+            electronic_ticket_indicator,
+            legs,
+            ..Default::default()
+        },
+    ))
 }
 
 /// Parses a boarding pass from `input_data` representable as a string reference.
-pub fn from_str<I>(input_data: I) -> Result<bcbp::Bcbp> where I: AsRef<str> {
+pub fn from_str<I>(input_data: I) -> Result<bcbp::Bcbp>
+where
+    I: AsRef<str>,
+{
     let input = input_data.as_ref();
     if !input.is_ascii() {
-        return Err(Error::InvalidCharacters)
+        return Err(Error::InvalidCharacters);
     }
 
-    let mut scanner = Scanner::new(input);
-
-    // Check that the input string is likely an M-type BCBP string.
-    if scanner.scan_str_field(field::Field::FormatCode)? != "M" {
+    // Sanity-check that the input is likely an IATA Type M BCBP Boarding Pass.
+    if !format_code_m(input).is_ok() {
         return Err(Error::UnsupportedFormat);
     }
 
-    // The number of legs informs the breakdown of the various field iterators.
-    let number_of_legs_encoded = scanner.scan_unsigned_field(field::Field::NumberOfLegsEncoded, 10)?;
+    // Pass the provided input data with the nom combinator and map the error.
+    let (remainder, boarding_pass) = bcbp(input).map_err(|e| match e {
+        nom::Err::Incomplete(_) => 
+            Error::UnexpectedEndOfInput,
+        nom::Err::Error(verbose_error) | nom::Err::Failure(verbose_error) =>
+            Error::ParseFailed(convert_error(input, verbose_error)),
+    })?;
 
-    // Create a parser for the mandatory unique fields.
-    let mut bcbp = bcbp::Bcbp::default();
-    bcbp.passenger_name =
-        scanner.scan_str_field(field::Field::PassengerName)?.into();
-    bcbp.electronic_ticket_indicator =
-        scanner.scan_char_field(field::Field::ElectronicTicketIndicator)?;
-
-    for leg_index in 0 .. number_of_legs_encoded {
-        let mut leg = bcbp::Leg::default();
-        
-        // Mandatory fields common to all legs.
-        leg.operating_carrier_pnr_code =
-            scanner.scan_str_field(field::Field::OperatingCarrierPnrCode)?.into();
-        leg.from_city_airport_code =
-            scanner.scan_str_field(field::Field::FromCityAirportCode)?.into();
-        leg.to_city_airport_code =
-            scanner.scan_str_field(field::Field::ToCityAirportCode)?.into();
-        leg.operating_carrier_designator =
-            scanner.scan_str_field(field::Field::OperatingCarrierDesignator)?.into();
-        leg.flight_number =
-            scanner.scan_str_field(field::Field::FlightNumber)?.into();
-        leg.date_of_flight =
-            scanner.scan_str_field(field::Field::DateOfFlight)?.into();
-        leg.compartment_code =
-            scanner.scan_char_field(field::Field::CompartmentCode)?;
-        leg.seat_number =
-            scanner.scan_str_field(field::Field::SeatNumber)?.into();
-        leg.check_in_sequence_number =
-            scanner.scan_str_field(field::Field::CheckInSequenceNumber)?.into();
-        leg.passenger_status =
-            scanner.scan_char_field(field::Field::PassengerStatus)?;
-
-        // Field size of the variable size field that follows for the leg.
-        let conditional_item_size = scanner.scan_unsigned_field(field::Field::FieldSizeOfVariableSizeField, 16)?;
-        if conditional_item_size > 0 {
- 
-            // Scanner over the entire set of conditional fields.
-            let mut conditional_item_scanner = scanner.scan_subsection(conditional_item_size as usize)?;
-
-            // The first leg may contain some optional fields at the root level.
-            if leg_index == 0 {
-
-                // Validate the beginning of version number tag as a sanity check.
-                if conditional_item_scanner.remaining_len() > 0 {
-                    if conditional_item_scanner.scan_str_field(field::Field::BeginningOfVersionNumber)? != ">" {
-                        return Err(Error::InvalidStartOfVersionNumber);
-                    }
-                }
-
-                // The version number is part of the structure and must be consumed, but is not used.
-                if conditional_item_scanner.remaining_len() > 0 {
-                    let _ = conditional_item_scanner.scan_str_field(field::Field::VersionNumber)?;
-                }
-
-                // Conditional unique fields are embedded in their own variable-length wrapper.
-                if conditional_item_scanner.remaining_len() > 0 {
-                    let len = conditional_item_scanner.scan_unsigned_field(field::Field::FieldSizeOfStructuredMessageUnique, 16)?;
-                    if len > 0 {
-                        let mut unique_scanner = conditional_item_scanner.scan_subsection(len as usize)?;
-
-                        bcbp.passenger_description =
-                            unique_scanner.scan_optional_char_field(field::Field::PassengerDescription)?;
-                        bcbp.source_of_check_in =
-                            unique_scanner.scan_optional_char_field(field::Field::SourceOfCheckIn)?;
-                        bcbp.source_of_boarding_pass_issuance =
-                            unique_scanner.scan_optional_char_field(field::Field::SourceOfBoardingPassIssuance)?;
-                        bcbp.date_of_issue_of_boarding_pass =
-                            unique_scanner.scan_optional_str_field(field::Field::DateOfIssueOfBoardingPass)?.map(Into::into);
-                        bcbp.document_type =
-                            unique_scanner.scan_optional_char_field(field::Field::DocumentType)?;
-                        bcbp.airline_designator_of_boarding_pass_issuer =
-                            unique_scanner.scan_optional_str_field(field::Field::AirlineDesignatorOfBoardingPassIssuer)?.map(Into::into);
-                        bcbp.baggage_tag_license_plate_numbers =
-                            unique_scanner.scan_optional_str_field(field::Field::BaggageTagLicensePlateNumbers)?.map(Into::into);
-                        bcbp.first_non_consecutive_baggage_tag_license_plate_numbers =
-                            unique_scanner.scan_optional_str_field(field::Field::FirstNonConsecutiveBaggageTagLicensePlateNumbers)?.map(Into::into);
-                        bcbp.second_non_consecutive_baggage_tag_license_plate_numbers =
-                            unique_scanner.scan_optional_str_field(field::Field::SecondNonConsecutiveBaggageTagLicensePlateNumbers)?.map(Into::into);
-                    }
-                }
-            }
-
-            // Conditional fields common to all legs.
-            if conditional_item_scanner.remaining_len() > 0 {
-                let len = conditional_item_scanner.scan_unsigned_field(field::Field::FieldSizeOfStructuredMessageRepeated, 16)?;
-                if len > 0 {
-                    let mut repeated_scanner = conditional_item_scanner.scan_subsection(len as usize)?;
-
-                    leg.airline_numeric_code =
-                        repeated_scanner.scan_optional_str_field(field::Field::AirlineNumericCode)?.map(Into::into);
-                    leg.document_form_serial_number =
-                        repeated_scanner.scan_optional_str_field(field::Field::DocumentFormSerialNumber)?.map(Into::into);
-                    leg.selectee_indicator =
-                        repeated_scanner.scan_optional_char_field(field::Field::SelecteeIndicator)?;
-                    leg.international_document_verification =
-                        repeated_scanner.scan_optional_char_field(field::Field::InternationalDocumentVerification)?;
-                    leg.marketing_carrier_designator =
-                        repeated_scanner.scan_optional_str_field(field::Field::MarketingCarrierDesignator)?.map(Into::into);
-                    leg.frequent_flyer_airline_designator =
-                        repeated_scanner.scan_optional_str_field(field::Field::FrequentFlyerAirlineDesignator)?.map(Into::into);
-                    leg.frequent_flyer_number =
-                        repeated_scanner.scan_optional_str_field(field::Field::FrequentFlyerNumber)?.map(Into::into);
-                    leg.id_ad_indicator =
-                        repeated_scanner.scan_optional_char_field(field::Field::IdAdIndicator)?;
-                    leg.free_baggage_allowance =
-                        repeated_scanner.scan_optional_str_field(field::Field::FreeBaggageAllowance)?.map(Into::into);
-                    leg.fast_track =
-                        repeated_scanner.scan_optional_char_field(field::Field::FastTrack)?;
-                }
-            }
-
-            // Any remaining text is ascribed to airline use.
-            if conditional_item_scanner.remaining_len() > 0 {
-                let remaining_len = conditional_item_scanner.remaining_len();
-                let body = conditional_item_scanner.scan_str_field_len(field::Field::AirlineIndividualUse, remaining_len)?;
-                leg.airline_individual_use = Some(body.into());
-            }
-        }
-
-        bcbp.legs.push(leg);
-    }
-
-    // Remaining input is ascribed to Security Data.
-    if scanner.remaining_len() > 0 {
-        if scanner.scan_str_field(field::Field::BeginningOfSecurityData)? != "^" {
-            return Err(Error::InvalidStartOfSecurityData);
-        }
-
-        let mut security_data = bcbp::SecurityData::default();
-
-        // The security data type captured as a separate field set as the next field, data length, is discarded.
-        security_data.type_of_security_data =
-            scanner.scan_optional_char_field(field::Field::TypeOfSecurityData)?;
-
-        // Scan the length of the security data.
-        if scanner.remaining_len() > 0 {
-            let len = scanner.scan_unsigned_field(field::Field::LengthOfSecurityData, 16)?;
-            if len > 0 {
-                let body = scanner.scan_str_field_len(field::Field::SecurityData, len as usize)?;
-                security_data.security_data = Some(body.into());
-            }
-        }
-
-        bcbp.security_data = security_data;
-    }
-
-    if !scanner.is_at_end() {
+    if remainder.len() > 0 {
         Err(Error::TrailingCharacters)
     } else {
-        Ok(bcbp)
+        Ok(boarding_pass)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(from_str("M1MROZ/MARTIN         EXXXXXX SJCLAXAS 3317 207U001A0006 34D>218 VV8207BAS              2502771980993865 AS AS XXXXX55200000000Z29  00010"), Err(Error::TrailingCharacters));
     }
 }

--- a/src/de/parser.rs
+++ b/src/de/parser.rs
@@ -406,7 +406,7 @@ where
 
     // Pass the provided input data with the nom combinator and map the error.
     let (remainder, boarding_pass) = bcbp(input).map_err(|e| match e {
-        nom::Err::Incomplete(_) => 
+        nom::Err::Incomplete(_) =>
             Error::UnexpectedEndOfInput,
         nom::Err::Error(verbose_error) | nom::Err::Failure(verbose_error) =>
             Error::ParseFailed(convert_error(input, verbose_error)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,25 +7,17 @@ use std::error;
 use std::fmt;
 use std::result;
 
-use de::field;
-
-#[derive(Clone,Eq,PartialEq,Ord,PartialOrd,Hash,Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Error {
-    /// The end of the input was reached prematurely.
-    UnexpectedEndOfInput(field::Field),
-    /// The length of the subsection encoded exceeds the remaining length of the input.
-    SubsectionTooLong,
-    /// The contents of a field parsed as a numeric was not a numeric value.
-    ExpectedInteger(field::Field),
-    /// The start-of-version-number value is not valid.
-    InvalidStartOfVersionNumber,
-    /// The start-of-security-data value is not valid.
-    InvalidStartOfSecurityData,
     /// The BCBP string does not contain exclusively ASCII characters.
     InvalidCharacters,
     /// The BCBP format is not supported.
     UnsupportedFormat,
-    /// After parsing, additional characters remain.
+    /// The end of otherwise-valid IATA BCBP data was reached prematurely.
+    UnexpectedEndOfInput,
+    /// Parsing the encoded data failed.
+    ParseFailed(String),
+    /// After successfully parsing a BCBP object, additional characters remain.
     TrailingCharacters,
 }
 
@@ -34,20 +26,14 @@ impl error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &Error::UnexpectedEndOfInput(field) =>
-                write!(f, "unexpected end-of-input before {}", field),
-            &Error::SubsectionTooLong =>
-                write!(f, "subsection too long"),
-            &Error::ExpectedInteger(field) =>
-                write!(f, "the {} field is non-numeric", field),
-            &Error::InvalidStartOfVersionNumber =>
-                write!(f, "the version number field does not begin with the '>' marker"),
-            &Error::InvalidStartOfSecurityData =>
-                write!(f, "the security data section does not begin with the '^' marker"),
             &Error::InvalidCharacters =>
                 write!(f, "non-ASCII characters"),
             &Error::UnsupportedFormat =>
                 write!(f, "not an IATA BCBP Type M boarding pass"),
+            &Error::UnexpectedEndOfInput =>
+                write!(f, "unexpected end-of-input"),
+            &Error::ParseFailed(ref reason) =>
+                write!(f, "parse failed: {}", reason),
             &Error::TrailingCharacters =>
                 write!(f, "input includes data after a valid boarding pass"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@
 // of the MIT license.  See the LICENSE file for details.
 
 //! `iata_bcbp` is a Rust library for parsing IATA BCBP Type M
-//! objects conforming to versions 2 through 6 of the standard inclusively. 
-//! This format is used by airlines to encode boarding pass information into 
-//! electronic ticket itinerary document barcodes in addition to paper and 
+//! objects conforming to versions 2 through 6 of the standard inclusively.
+//! This format is used by airlines to encode boarding pass information into
+//! electronic ticket itinerary document barcodes in addition to paper and
 //! mobile boarding passes.
 //!
 //! # Example
@@ -14,7 +14,7 @@
 //! extern crate iata_bcbp;
 //!
 //! use std::str::FromStr;
-//! 
+//!
 //! use iata_bcbp::Bcbp;
 //!
 //! fn main() {
@@ -35,13 +35,13 @@
 //! }
 //! ```
 
-#[macro_use]
-extern crate log;
+extern crate arrayvec;
+extern crate nom;
 
 mod bcbp;
 mod de;
 mod error;
 
 pub use bcbp::{Bcbp, Leg, SecurityData};
-pub use de::{from_str, field::Field};
+pub use de::{field::Field, from_str};
 pub use error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,5 +43,5 @@ mod de;
 mod error;
 
 pub use bcbp::{Bcbp, Leg, SecurityData};
-pub use de::{field::Field, from_str};
+pub use de::from_str;
 pub use error::{Error, Result};

--- a/tests/iata_792_b.rs
+++ b/tests/iata_792_b.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.

--- a/tests/iata_792_b.rs
+++ b/tests/iata_792_b.rs
@@ -54,7 +54,8 @@ fn example_2_m2_multiple_legs() {
     assert_eq!(pass_data.first_non_consecutive_baggage_tag_license_plate_numbers(), None);
     assert_eq!(pass_data.second_non_consecutive_baggage_tag_license_plate_numbers(), None);
 
-    { // Fields in leg 1 of 2.
+    {
+        // Fields in leg 1 of 2.
         let first_leg = &pass_data.legs()[0];
         assert_eq!(first_leg.operating_carrier_pnr_code(), "ABC123 ");
         assert_eq!(first_leg.from_city_airport_code(), "YUL");
@@ -80,7 +81,8 @@ fn example_2_m2_multiple_legs() {
         assert_eq!(first_leg.airline_individual_use(), Some("LX58Z"));
     }
 
-    { // Fields in leg 2 of 2.
+    {
+        // Fields in leg 2 of 2.
         let second_leg = &pass_data.legs()[1];
         assert_eq!(second_leg.operating_carrier_pnr_code(), "DEF456 ");
         assert_eq!(second_leg.from_city_airport_code(), "FRA");
@@ -128,7 +130,8 @@ fn appendix_b_1_1_lh_home_printed_boarding_pass() {
     assert_eq!(pass_data.first_non_consecutive_baggage_tag_license_plate_numbers(), None);
     assert_eq!(pass_data.second_non_consecutive_baggage_tag_license_plate_numbers(), None);
 
-    { // Fields in leg 1 of 1.
+    {
+        // Fields in leg 1 of 1.
         let first_leg = &pass_data.legs()[0];
         assert_eq!(first_leg.operating_carrier_pnr_code(), "8OQ6FU ");
         assert_eq!(first_leg.from_city_airport_code(), "FRA");
@@ -169,7 +172,8 @@ fn appendix_b_1_2_kl_home_printed_boarding_pass() {
     assert_eq!(pass_data.source_of_check_in(), Some(' '));
     assert_eq!(pass_data.source_of_boarding_pass_issuance(), Some('W'));
 
-    { // Fields in leg 1 of 1.
+    {
+        // Fields in leg 1 of 1.
         let first_leg = &pass_data.legs()[0];
         assert_eq!(first_leg.operating_carrier_pnr_code(), "24Z5RN ");
         assert_eq!(first_leg.from_city_airport_code(), "AMS");
@@ -205,7 +209,8 @@ fn appendix_b_2_1_bcbp_printed_at_a_kiosk_ua_ua_kiosk() {
     assert_eq!(pass_data.first_non_consecutive_baggage_tag_license_plate_numbers(), None);
     assert_eq!(pass_data.second_non_consecutive_baggage_tag_license_plate_numbers(), None);
 
-    { // Fields in leg 1 of 1.
+    {
+        // Fields in leg 1 of 1.
         let first_leg = &pass_data.legs()[0];
         assert_eq!(first_leg.operating_carrier_pnr_code(), "A272SL ");
         assert_eq!(first_leg.from_city_airport_code(), "ORD");
@@ -252,7 +257,8 @@ fn appendix_b_3_1_mobile_bcbp_lh_lufthansa_mobile_bcbp() {
     assert_eq!(pass_data.first_non_consecutive_baggage_tag_license_plate_numbers(), None);
     assert_eq!(pass_data.second_non_consecutive_baggage_tag_license_plate_numbers(), None);
 
-    { // Fields in leg 1 of 1.
+    {
+        // Fields in leg 1 of 1.
         let first_leg = &pass_data.legs()[0];
         assert_eq!(first_leg.operating_carrier_pnr_code(), "8OQ6FU ");
         assert_eq!(first_leg.from_city_airport_code(), "FRA");

--- a/tests/invalid_input.rs
+++ b/tests/invalid_input.rs
@@ -15,66 +15,106 @@ use iata_bcbp::*;
 fn trailing_characters() {
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, with a trailing '+'.
     const PASS_STR: &str = "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^100+";
-    assert_eq!(Bcbp::from_str(PASS_STR), Err(Error::TrailingCharacters));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR),
+        Err(Error::TrailingCharacters)
+    );
 }
 
 #[test]
 fn unsupported_format() {
     // The first character indicates the format. This is a valid Type 'M' boarding pass from the IATA 792B examples, with the wrong format code.
     const PASS_STR_S: &str = "S1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^100";
-    assert_eq!(Bcbp::from_str(PASS_STR_S), Err(Error::UnsupportedFormat));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR_S), 
+        Err(Error::UnsupportedFormat)
+    );
+
+    // This is the same valid Type 'M' boarding pass but with a lower-case 'm' format specifier.
     const PASS_STR_LITTLE_M: &str = "m1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^100";
-    assert_eq!(Bcbp::from_str(PASS_STR_LITTLE_M), Err(Error::UnsupportedFormat));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR_LITTLE_M), 
+        Err(Error::UnsupportedFormat)
+    );
 }
 
 #[test]
 fn invalid_characters() {
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, with a non-ASCII character.
     const PASS_STR: &str = "M1DESMARAIS/LUç       EABC123 YULFRAAC 0834 326J001A0025 100^100";
-    assert_eq!(Bcbp::from_str(PASS_STR), Err(Error::InvalidCharacters));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR), 
+        Err(Error::InvalidCharacters)
+    );
+
+    // This is invalid data with a non-ASCII character.
     const PASS_STR_MINIMAL: &str = "ç";
-    assert_eq!(Bcbp::from_str(PASS_STR_MINIMAL), Err(Error::InvalidCharacters));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR_MINIMAL),
+        Err(Error::InvalidCharacters)
+    );
 }
 
 #[test]
 fn invalid_start_of_security_data() {
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, using a '+' instead of '^' for start of security data.
     const PASS_STR: &str = "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100+100";
-    assert_eq!(Bcbp::from_str(PASS_STR), Err(Error::InvalidStartOfSecurityData));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR),
+        Err(Error::ParseFailed(String::from("")))
+    );
 }
 
 #[test]
 fn invalid_start_of_version_number() {
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, using a '+' instead of '>' for start of version number.
     const PASS_STR: &str = "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 14D+6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^100";
-    assert_eq!(Bcbp::from_str(PASS_STR), Err(Error::InvalidStartOfVersionNumber));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR),
+        Err(Error::ParseFailed(String::from("")))
+    );
 }
 
 #[test]
 fn expected_integer() {
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, with leg count 'X'.
     const PASS_STR_1: &str = "MXDESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^100+";
-    assert_eq!(Bcbp::from_str(PASS_STR_1), Err(Error::ExpectedInteger(Field::NumberOfLegsEncoded)));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR_1),
+        Err(Error::ParseFailed(String::from("")))
+    );
 
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, with security data length 'YY'.
     const PASS_STR_2: &str = "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^1YY";
-    assert_eq!(Bcbp::from_str(PASS_STR_2), Err(Error::ExpectedInteger(Field::LengthOfSecurityData)));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR_2),
+        Err(Error::ParseFailed(String::from("")))
+    );
 }
 
 #[test]
 fn subsection_too_long() {
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, with an 'FF' long conditional.
     const PASS_STR: &str = "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 1FF>6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^100";
-    assert_eq!(Bcbp::from_str(PASS_STR), Err(Error::SubsectionTooLong));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR),
+        Err(Error::ParseFailed(String::from("")))
+    );
 }
 
 #[test]
 fn unexpected_end_of_input() {
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, with a security data extending past end of input.
     const PASS_STR_SEC: &str = "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 14D>6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^101";
-    assert_eq!(Bcbp::from_str(PASS_STR_SEC), Err(Error::UnexpectedEndOfInput(Field::SecurityData)));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR_SEC),
+        Err(Error::UnexpectedEndOfInput)
+    );
 
     // This is an incomplete type M pass truncated half way through the name field.
     const PASS_STR_NAME: &str = "M2DESMARAIS";
-    assert_eq!(Bcbp::from_str(PASS_STR_NAME), Err(Error::UnexpectedEndOfInput(Field::PassengerName)));
+    assert_eq!(
+        Bcbp::from_str(PASS_STR_NAME),
+        Err(Error::UnexpectedEndOfInput)
+    );
 }

--- a/tests/invalid_input.rs
+++ b/tests/invalid_input.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.
@@ -61,7 +61,17 @@ fn invalid_start_of_security_data() {
     const PASS_STR: &str = "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100+100";
     assert_eq!(
         Bcbp::from_str(PASS_STR),
-        Err(Error::ParseFailed(String::from("")))
+        Err(Error::ParseFailed(
+            "0: at line 0:\n".to_owned() +
+            "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100+100\n" +
+            "                                                            ^\n" +
+            "expected '^', found +\n" +
+            "\n" +
+            "1: at line 0, in Beginning of Security Data:\n" +
+            "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100+100\n" +
+            "                                                            ^\n" +
+            "\n"
+        ))
     );
 }
 

--- a/tests/invalid_input.rs
+++ b/tests/invalid_input.rs
@@ -61,8 +61,8 @@ fn invalid_start_of_security_data() {
     const PASS_STR: &str = "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100+100";
     assert_eq!(
         Bcbp::from_str(PASS_STR),
-        Err(Error::ParseFailed(
-            "0: at line 0:\n".to_owned() +
+        Err(Error::ParseFailed(String::new() +
+            "0: at line 0:\n" +
             "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100+100\n" +
             "                                                            ^\n" +
             "expected '^', found +\n" +
@@ -81,7 +81,17 @@ fn invalid_start_of_version_number() {
     const PASS_STR: &str = "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 14D+6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^100";
     assert_eq!(
         Bcbp::from_str(PASS_STR),
-        Err(Error::ParseFailed(String::from("")))
+        Err(Error::ParseFailed(String::new() +
+            "0: at line 0:\n" +
+            "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 14D+6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^100\n" +
+            "                                                            ^\n" +
+            "expected \'>\', found +\n" +
+            "\n" +
+            "1: at line 0, in Beginning of Version Number:\n" +
+            "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 14D+6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^100\n" +
+            "                                                            ^\n" +
+            "\n"
+        ))
     );
 }
 
@@ -91,14 +101,32 @@ fn expected_integer() {
     const PASS_STR_1: &str = "MXDESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^100+";
     assert_eq!(
         Bcbp::from_str(PASS_STR_1),
-        Err(Error::ParseFailed(String::from("")))
+        Err(Error::ParseFailed(String::new() +
+            "0: at line 0, in TakeWhileMN:\n" +
+            "MXDESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^100+\n" +
+            " ^\n" +
+            "\n" +
+            "1: at line 0, in Number of Legs Encoded:\n" +
+            "MXDESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^100+\n" +
+            " ^\n" +
+            "\n"
+        ))
     );
 
     // This is a complete and valid Type 'M' boarding pass from the IATA 792B examples, with security data length 'YY'.
     const PASS_STR_2: &str = "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^1YY";
     assert_eq!(
         Bcbp::from_str(PASS_STR_2),
-        Err(Error::ParseFailed(String::from("")))
+        Err(Error::ParseFailed(String::new() +
+            "0: at line 0, in TakeWhileMN:\n" +
+            "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^1YY\n" +
+            "                                                              ^\n" +
+            "\n" +
+            "1: at line 0, in Length of Security Data:\n" + 
+            "M1DESMARAIS/LUC       EABC123 YULFRAAC 0834 326J001A0025 100^1YY\n" +
+            "                                                              ^\n" +
+            "\n"
+        ))
     );
 }
 
@@ -108,7 +136,12 @@ fn subsection_too_long() {
     const PASS_STR: &str = "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 1FF>6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^100";
     assert_eq!(
         Bcbp::from_str(PASS_STR),
-        Err(Error::ParseFailed(String::from("")))
+        Err(Error::ParseFailed(String::new() +
+            "0: at line 0, in Eof:\n" +
+            "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 1FF>6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^100\n" +
+            "                                                            ^\n" +
+            "\n"
+        ))
     );
 }
 
@@ -118,13 +151,27 @@ fn unexpected_end_of_input() {
     const PASS_STR_SEC: &str = "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 14D>6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^101";
     assert_eq!(
         Bcbp::from_str(PASS_STR_SEC),
-        Err(Error::UnexpectedEndOfInput)
+        Err(Error::ParseFailed(String::new() +
+            "0: at line 0, in Eof:\n" +
+            "M2DESMARAIS/LUC       EABC123 YULFRAAC 0834 226F001A0025 14D>6181WW6225BAC 00141234560032A0141234567890 1AC AC 1234567890123    20KYLX58ZDEF456 FRAGVALH 3664 227C012C0002 12E2A0140987654321 1AC AC 1234567890123    2PCNWQ^101\n" +
+            "                                                                                                                                                                                                                                ^\n" +
+            "\n"
+        ))
     );
 
     // This is an incomplete type M pass truncated half way through the name field.
     const PASS_STR_NAME: &str = "M2DESMARAIS";
     assert_eq!(
         Bcbp::from_str(PASS_STR_NAME),
-        Err(Error::UnexpectedEndOfInput)
+        Err(Error::ParseFailed(String::new() +
+            "0: at line 0, in Eof:\n" +
+            "M2DESMARAIS\n" +
+            "  ^\n" +
+            "\n" +
+            "1: at line 0, in Passenger Name:\n" +
+            "M2DESMARAIS\n" +
+            "  ^\n" +
+            "\n"
+        ))
     );
 }

--- a/tests/not_yet_supported.rs
+++ b/tests/not_yet_supported.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.

--- a/tests/real_world.rs
+++ b/tests/real_world.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Martin Mroz
+// Copyright (C) 2019 Martin Mroz
 //
 // This software may be modified and distributed under the terms
 // of the MIT license.  See the LICENSE file for details.

--- a/tests/real_world.rs
+++ b/tests/real_world.rs
@@ -29,7 +29,8 @@ fn alaska_boarding_pass() {
     assert_eq!(pass_data.first_non_consecutive_baggage_tag_license_plate_numbers(), None);
     assert_eq!(pass_data.second_non_consecutive_baggage_tag_license_plate_numbers(), None);
 
-    { // Fields in leg 1 of 1.
+    {
+        // Fields in leg 1 of 1.
         let first_leg = &pass_data.legs()[0];
         assert_eq!(first_leg.operating_carrier_pnr_code(), "XXXXXX ");
         assert_eq!(first_leg.from_city_airport_code(), "SJC");
@@ -74,7 +75,8 @@ fn air_canada_boarding_pass() {
     assert_eq!(pass_data.first_non_consecutive_baggage_tag_license_plate_numbers(), None);
     assert_eq!(pass_data.second_non_consecutive_baggage_tag_license_plate_numbers(), None);
 
-    { // Fields in leg 1 of 1.
+    {
+        // Fields in leg 1 of 1.
         let first_leg = &pass_data.legs()[0];
         assert_eq!(first_leg.operating_carrier_pnr_code(), "XXXXXX ");
         assert_eq!(first_leg.from_city_airport_code(), "YVR");


### PR DESCRIPTION
- Implements a new parser for the IATA BCBP type-M format implemented with nom. 
- A verbose error is generated to help track down issues with input format. 
- Logging is no longer done, and as such there is no longer a dependency on the log crate.
- Each string field is now a statically-allocated ArrayString to dramatically reduce allocation count.
- Update to Rust 2018 edition.